### PR TITLE
Support custom transceiver implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ pub use crate::crypto::{generate_key, try_generate_key, Key};
 pub use crate::error::{Error, Result};
 pub use crate::server::{ClientId, ClientIndex, Server, ServerConfig};
 pub use crate::token::{ConnectToken, ConnectTokenBuilder, InvalidTokenError};
+pub use crate::transceiver::Transceiver;
 
 /// The size of a private key in bytes.
 pub const PRIVATE_KEY_BYTES: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! 1. The `Client` authenticates with the web backend service. (e.g., by OAuth or some other means)
 //! 2. The authenticated `Client` requests a connection token from the web backend.
-//! 3. The web backend generates a [`ConnectToken`](ConnectToken) and sends it to the `Client`. (e.g., as a JSON response)
+//! 3. The web backend generates a [`ConnectToken`] and sends it to the `Client`. (e.g., as a JSON response)
 //! 4. The `Client` uses the token to connect to a dedicated `Server`.
 //! 5. The `Server` makes sure the token is valid and allows the `Client` to connect.
 //! 6. The `Client` and `Server` can now exchange encrypted and signed UDP packets.
@@ -39,7 +39,7 @@
 //!  * Provide the address you intend to bind to.
 //!  * Provide the protocol id - a `u64` that uniquely identifies your app.
 //!  * Provide a private key - a `u8` array of length 32. If you don't have one, you can generate one with `netcode::generate_key()`.
-//!  * Optionally provide a [`ServerConfig`](ServerConfig) - a struct that allows you to customize the server's behavior.
+//!  * Optionally provide a [`ServerConfig`] - a struct that allows you to customize the server's behavior.
 //!
 //! ```
 //! use std::{thread, time::{Instant, Duration}};
@@ -72,8 +72,8 @@
 //! send updates to the server, and maintain a stable connection.
 //!
 //! To create a client:
-//!  * Provide a **connect token** - a `u8` array of length 2048 serialized from a [`ConnectToken`](ConnectToken).
-//!  * Optionally provide a [`ClientConfig`](ClientConfig) - a struct that allows you to customize the client's behavior.
+//!  * Provide a **connect token** - a `u8` array of length 2048 serialized from a [`ConnectToken`].
+//!  * Optionally provide a [`ClientConfig`] - a struct that allows you to customize the client's behavior.
 //!
 //! ```
 //! use std::{thread, time::{Instant, Duration}};

--- a/src/server.rs
+++ b/src/server.rs
@@ -356,7 +356,7 @@ impl Server<NetcodeSocket> {
             sequence: 1 << 63,
             token_sequence: 0,
             challenge_sequence: 0,
-            challenge_key: crypto::generate_key(),
+            challenge_key: crypto::try_generate_key()?,
             conn_cache: ConnectionCache::new(0.0),
             token_entries: TokenEntries::new(),
             cfg: ServerConfig::default(),
@@ -398,7 +398,7 @@ impl<Ctx> Server<NetcodeSocket, Ctx> {
             sequence: 1 << 63,
             token_sequence: 0,
             challenge_sequence: 0,
-            challenge_key: crypto::generate_key(),
+            challenge_key: crypto::try_generate_key()?,
             conn_cache: ConnectionCache::new(0.0),
             token_entries: TokenEntries::new(),
             cfg,
@@ -709,6 +709,35 @@ impl<T: Transceiver, S> Server<T, S> {
         }
         Ok(())
     }
+    /// Creates a new server instance with the given configuration and transceiver.
+    ///
+    /// This is useful if you want to use a custom transceiver implementation,
+    /// in any other case you should use [`Server::new`](Server::new) or [`Server::with_config`](Server::with_config).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use netcode::{Server, ServerConfig, Transceiver};
+    ///
+    /// struct MyTransceiver {
+    ///    // ...
+    /// };
+    ///
+    /// impl Transceiver for MyTransceiver {
+    ///    // ...
+    ///    # type IntoError = std::io::Error;
+    ///    # fn addr(&self) -> std::net::SocketAddr { unimplemented!() }
+    ///    # fn send(&self, buf: &[u8], addr: std::net::SocketAddr) -> std::io::Result<usize> { unimplemented!() }
+    ///    # fn recv(&self, buf: &mut [u8]) -> std::io::Result<Option<(usize, std::net::SocketAddr)>> { unimplemented!() }
+    /// }
+    ///
+    /// let protocol_id = 0x1122334455667788;
+    /// let private_key = netcode::generate_key();
+    /// let cfg = ServerConfig::default();
+    /// let trx = MyTransceiver { /* .. */ };
+    ///
+    /// let server = Server::with_config_and_transceiver(protocol_id, private_key, cfg, trx).unwrap();
+    /// ```
     pub fn with_config_and_transceiver(
         protocol_id: u64,
         private_key: Key,
@@ -723,7 +752,7 @@ impl<T: Transceiver, S> Server<T, S> {
             sequence: 1 << 63,
             token_sequence: 0,
             challenge_sequence: 0,
-            challenge_key: crypto::generate_key(),
+            challenge_key: crypto::try_generate_key()?,
             conn_cache: ConnectionCache::new(0.0),
             token_entries: TokenEntries::new(),
             cfg,
@@ -923,21 +952,9 @@ pub mod tests {
             sim: NetworkSimulator,
             private_key: Option<Key>,
         ) -> Result<Self> {
-            let time = 0.0;
-            log::info!("server started on {}", sim.addr());
-            let server = Server {
-                transceiver: sim,
-                time,
-                private_key: private_key.unwrap_or(crypto::generate_key()),
-                protocol_id: 0,
-                sequence: 1 << 63,
-                token_sequence: 0,
-                challenge_sequence: 0,
-                challenge_key: crypto::generate_key(),
-                conn_cache: ConnectionCache::new(time),
-                token_entries: TokenEntries::new(),
-                cfg: ServerConfig::default(),
-            };
+            let private_key = private_key.unwrap_or(crypto::generate_key());
+            let cfg = ServerConfig::default();
+            let server = Server::with_config_and_transceiver(0, private_key, cfg, sim)?;
             Ok(server)
         }
         pub(crate) fn iter_clients(&self) -> impl Iterator<Item = ClientIndex> + '_ {

--- a/src/server.rs
+++ b/src/server.rs
@@ -709,6 +709,28 @@ impl<T: Transceiver, S> Server<T, S> {
         }
         Ok(())
     }
+    pub fn with_config_and_transceiver(
+        protocol_id: u64,
+        private_key: Key,
+        cfg: ServerConfig<S>,
+        trx: T,
+    ) -> Result<Self> {
+        let server = Server {
+            transceiver: trx,
+            time: 0.0,
+            private_key,
+            protocol_id,
+            sequence: 1 << 63,
+            token_sequence: 0,
+            challenge_sequence: 0,
+            challenge_key: crypto::generate_key(),
+            conn_cache: ConnectionCache::new(0.0),
+            token_entries: TokenEntries::new(),
+            cfg,
+        };
+        log::info!("server started on {}", server.addr());
+        Ok(server)
+    }
     /// Updates the server.
     ///
     /// * Updates the server's elapsed time.

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -68,13 +68,13 @@ fn rand_float(range: std::ops::Range<f64>) -> f64 {
 }
 
 impl Transceiver for NetworkSimulator {
-    type Error = io::Error;
+    type IntoError = io::Error;
 
     fn addr(&self) -> SocketAddr {
         SocketAddr::from((Ipv4Addr::LOCALHOST, self.port))
     }
 
-    fn recv(&self, buf: &mut [u8]) -> Result<Option<(usize, SocketAddr)>, Self::Error> {
+    fn recv(&self, buf: &mut [u8]) -> Result<Option<(usize, SocketAddr)>, Self::IntoError> {
         // routing table -> given an addr of self, look through the table for the receiving endpoint
         // if no entry is found, return early
         let table = self.routing_table.borrow();
@@ -94,7 +94,7 @@ impl Transceiver for NetworkSimulator {
         }
         Ok(None)
     }
-    fn send(&self, buf: &[u8], addr: SocketAddr) -> Result<usize, Self::Error> {
+    fn send(&self, buf: &[u8], addr: SocketAddr) -> Result<usize, Self::IntoError> {
         // routing table -> given an addr, look through the table for the sending endpoint
         // if no entry is found, return early
         let table = self.routing_table.borrow();

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -35,7 +35,7 @@ impl NetcodeSocket {
 }
 
 impl Transceiver for NetcodeSocket {
-    type Error = Error;
+    type IntoError = Error;
 
     fn addr(&self) -> SocketAddr {
         self.0.local_addr().expect("address should be bound")

--- a/src/transceiver.rs
+++ b/src/transceiver.rs
@@ -4,12 +4,23 @@ use crate::error::Error;
 
 /// A trait for sending and receiving data.
 ///
-/// This trait is implemented for `NetcodeSocket` and `NetworkSimulator`.
+/// Both the server and client use a statically dispatched generic type `T: Transceiver` to send and receive data,
+/// which allows you to use any type that implements this trait as your network socket for a `netcode` server or client.
 ///
-/// The server uses a statically dispatched generic type transceiver to send and receive data.
+/// See [`NetcodeSocket`](https://github.com/benny-n/netcode/blob/0147a2d11cb48dea59a637ca2f017912f3f6d9aa/src/socket.rs#L37) for an example implementation.
+/// This is also the default implementation used by the server and client.
 pub trait Transceiver {
-    type Error: Into<Error>;
+    type IntoError: Into<Error>;
+    /// Returns the local address of the socket (i.e. the address it is bound to).
+    ///
+    /// Mostly used for generating and validating [`ConnectTokens`](crate::ConnectToken).
     fn addr(&self) -> SocketAddr;
-    fn recv(&self, buf: &mut [u8]) -> Result<Option<(usize, SocketAddr)>, Self::Error>;
-    fn send(&self, buf: &[u8], addr: SocketAddr) -> Result<usize, Self::Error>;
+    /// Receives a packet from the socket, if one is available.
+    ///
+    /// Should **NOT** block if no packet is available.
+    fn recv(&self, buf: &mut [u8]) -> Result<Option<(usize, SocketAddr)>, Self::IntoError>;
+    /// Sends a packet to the specified address.
+    ///
+    /// Should **NOT** block if the packet cannot be sent.
+    fn send(&self, buf: &[u8], addr: SocketAddr) -> Result<usize, Self::IntoError>;
 }


### PR DESCRIPTION
 * The `Transceiver` trait is now public by being exported at the crate level.
 * Added `Server:: with_config_and_transceiver` to allow creating a `Server` with a custom `Transceiver` implementation.
 * Added `Client:: with_config_and_transceiver` to allow creating a `Client` with a custom `Transceiver` implementation.